### PR TITLE
x-peria

### DIFF
--- a/iphone.txt
+++ b/iphone.txt
@@ -5,4 +5,4 @@ Të dy modelet e reja të iPhone pritet ta sjellin procesorin e ri Apple A9 që do 
 
 Kamera e përparme pritet të vijë me Full HD FaceTime, ndërsa kamera e pasme pritet të ofrojë 12MP me mundësi të incizimit të videove në 4K.
 
-Modelet e reja të iPhone 6S dhe 6S Plus pritet të vijnë dikur në shtator, ndërsa bashkë me dy modelet e reja të telefonave pritet të vijë edhe Apple TV dhe iPad Pro.
+Modelet e reja të iPhone 6S dhe 6S Plus pritet të vijnë dikur në shtator, ndërsa bashkë me dy modelet e reja të telefonave pritet të vijë edhe Apple TV dhe iPad Pro. iphone 6 ka pas suksem me shume se samsung s6.


### PR DESCRIPTION
Sony Xperia M5 është projektuar të jetë rezistent ndaj pluhurit dhe ujit, dhe e njëjta e përmban standardin IP65 dhe IP68, ndërsa telefoni gjithashtu vjen me ekranin 5 inç në Full HD me rezolucion prej 1920 x 1080 pikselëve.

Karakteristikat tjera të Xperia M5 e përfshijnë edhe procesorin 64 bit Mediatek Helio X10 okta core në 2GHz.

Telefoni i ri nga Sony gjithashtu vjen me 3GB RAM, 16FGB memorie për ruajtjen e përmbajtjes, portin për kartelën microSD e cila mund ta zgjerojë hapësirën deri në 200GB.
Pajisja ka edhe kamerën e fuqishme në pjesën e përparme me 13MP për selfie dhe video Full në 1080p, ndërkaq kamera e pasme vjen me 21.5MP Sony Exmor RS me Hybrid FA, si dhe 5x zoom dhe mundësi incizimi të videove në 4K.

Sony kanë thënë se telefoni i saj i ri Sony Xperia M5 do të dalë në shitje në vendet e zgjedhura më vonë këtë muaj, edhepse ende nuk ka detaje për çmimet. Pajisja do të jetë në dispozicion në tri ngjyra, ari të bardhë dhe e zezë.
